### PR TITLE
郵便番号が示す地区が複数の時でも返り値が一つになるメソッドの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ If more than one address corresponds
       address.zip_code # 0790177
     end
 
+So if you want to get certainly one address
+
+    address = ZipCodeJp.find_first '0790177'
+    address.class # ZipCodeJp::Address
+
 Update the JSON data of postal code
 
     ZipCodeJp.export_json

--- a/lib/zip_code_jp.rb
+++ b/lib/zip_code_jp.rb
@@ -30,4 +30,13 @@ module ZipCodeJp
     end
     return false
   end
+
+  def find_first(zip_code)
+    result = find(zip_code)
+    if result.is_a? Array
+      result.first
+    else
+      result
+    end
+  end
 end

--- a/spec/zip_code_jp_spec.rb
+++ b/spec/zip_code_jp_spec.rb
@@ -34,6 +34,28 @@ describe ZipCodeJp do
     end
   end
 
+  describe '#find_first' do
+    subject { ZipCodeJp.find_first zip_code }
+
+    context 'when the zip code specifies an area' do
+      let(:zip_code) { '102-0072' }
+
+      it { is_expected.to be_an(ZipCodeJp::Address) }
+    end
+
+    context 'when the zip code specifies multiple areas' do
+      let(:zip_code) { '0790177' }
+
+      it { is_expected.to be_an(ZipCodeJp::Address) }
+    end
+
+    context 'when the zip code specifies no area' do
+      let(:zip_code) { '0000000' }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe 'ZipCodeJp.export_json' do
     it 'does NOT raise any errors' do
       expect { ZipCodeJp.export_json }.not_to raise_error


### PR DESCRIPTION
次のように郵便番号が示す地区が複数あり、`ZipCodeJp.find`の返り値が配列になることがある。

```ruby
zip = ZipCodeJp.find '0790177'
=> [#<ZipCodeJp::Address:0x007f8b70ba7248 @city="美唄市", @city_kana="ビバイシ", @prefecture="北海道", @prefecture_code=1, @prefecture_kana="ホッカイドウ", @town="上美唄町", @town_kana="カミビバイチョウ", @zip_code="0790177">,
 #<ZipCodeJp::Address:0x007f8b70ba7220 @city="美唄市", @city_kana="ビバイシ", @prefecture="北海道", @prefecture_code=1, @prefecture_kana="ホッカイドウ", @town="上美唄町協和", @town_kana="カミビバイチョウキョウワ", @zip_code="0790177">,
 #<ZipCodeJp::Address:0x007f8b70ba71f8 @city="美唄市", @city_kana="ビバイシ", @prefecture="北海道", @prefecture_code=1, @prefecture_kana="ホッカイドウ", @town="上美唄町南", @town_kana="カミビバイチョウミナミ", @zip_code="0790177">]
```

アプリケーション側でこれを判定して制御しないでも良いように配列の時、先頭を返すメソッドを追加する。